### PR TITLE
Fix explorer mode for basic-1 and string-literal constraints

### DIFF
--- a/symbolic-explorer/driver/SimpleDriver.py
+++ b/symbolic-explorer/driver/SimpleDriver.py
@@ -60,6 +60,7 @@ class SimpleDriver:
             f'-Dexplorer.port={self.args.port}',
             f'-javaagent:{self.args.agent}',
             f'-Djava.library.path={self.args.z3dir}',
+            '-Dsolver.mode=HTTP',
             '-ea',  # Enable assertions
         ]
 
@@ -172,8 +173,8 @@ class SimpleDriver:
                 # Array variables come in pairs: [I_0 (the array) and [I_0_length (the length)
                 # We only want to register the array itself, not the length
                 non_length_inputs = [inp for inp in branch.inputs if not inp.name.endswith('_length')]
-                var_types = [inp.type for inp in non_length_inputs]
-                var_indices = [int(inp.name.split('_')[-1]) for inp in non_length_inputs]
+                var_types = [inp.name.rsplit('_', 1)[0] for inp in non_length_inputs]
+                var_indices = [int(inp.name.rsplit('_', 1)[1]) for inp in non_length_inputs]
                 self.sym_storage.register_vars(var_types, var_indices)
                 self.sym_storage.store_solution(sol)
 

--- a/symbolic-explorer/parse/TraceParser.py
+++ b/symbolic-explorer/parse/TraceParser.py
@@ -14,14 +14,7 @@ class Parser:
         _trace = []
         for branch in trace:
             if branch.type == "Branch":
-                sanitized_constraint = ''
-                for c in branch.constraint:
-                    if ord(c) == 34:
-                        sanitized_constraint += '\\"'
-                    elif ord(c) == 10:
-                        sanitized_constraint += ''
-                    else:
-                        sanitized_constraint += c
+                sanitized_constraint = branch.constraint.replace('\n', '')
                 _trace.append(Branch(id=branch.iid,
                                      trace_id=trace_id,
                                      has_branched=branch.branched,

--- a/targets/examples/basic-1/run.sh
+++ b/targets/examples/basic-1/run.sh
@@ -23,7 +23,12 @@ echo "Running $target" in $mode mode
 # Execute based on the mode
 if [ "$mode" == "explorer" ]; then
     # Running the target from the symbolic explorer
-    python ../../../symbolic-explorer/SymbolicExplorer.py --target $target --agent ../../../symbolic-executor/lib/symbolic-executor.jar --z3dir ../../../libs/java-library-path
+    ../../../symbolic-explorer/.venv/bin/python3 ../../../symbolic-explorer/SymbolicExplorer.py \
+        --mode simple \
+        --target $target \
+        --classpath . \
+        --agent ../../../symbolic-executor/lib/symbolic-executor.jar \
+        --z3dir ../../../libs/java-library-path
 else
     # Running the target from the symbolic executor
     java \


### PR DESCRIPTION
TraceParser was escaping every " in branch constraints to \", which produced invalid SMT-LIB and made Z3 reject any path constraint that contained a string literal. The old SolverHandler.string_to_expr masked it with s.replace('\\', ''), but the rewritten solve() path (via ConstraintCache.parse_smt_string) has no such workaround, so the underlying bug now surfaces for any String input compared to a literal. Remove the bogus escape; keep the newline strip.

Also wire basic-1's run.sh through SimpleDriver: use the explorer's .venv interpreter, pass --mode simple and --classpath ., and add -Dsolver.mode=HTTP in SimpleDriver.build_command so constraints reach the explorer over HTTP (TargetDriver already had this; SimpleDriver was missing it). Finally, derive symbolic-variable types from the input name (java/lang/String_0 -> java/lang/String) instead of inp.type, which doesn't line up with the DataTypes enum for non-primitive sorts.