### PR TITLE
fix: make the test suite green — bitvector test modernization + production fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ targets/applications/openolat/libs/z3/
 libs/jacoco/report
 targets/applications/openhospital/oh_build/restler_working_dir/Compile
 targets/applications/openhospital/oh_build/restler_working_dir/RestlerResults
-targets/sv-comp/sv-benchmarks/*
+targets/sv-comp/sv-benchmarks/
+targets/sv-comp/wit4java/
 **/__pycache__
 **/.venv/*
 /.vscode/

--- a/symbolic-executor/build.gradle
+++ b/symbolic-executor/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 
 test {
     systemProperty "java.library.path", "../libs/java-library-path"
+    // Surface SWAT errors as exceptions instead of halting the test JVM
+    systemProperty "exitOnError", "false"
 
     testLogging {
         // Show events for passed, skipped, and failed tests

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/common/ErrorHandler.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/common/ErrorHandler.java
@@ -45,8 +45,9 @@ public class ErrorHandler {
     }
 
     /**
-     * Handles an exception with a custom message. Depending on the application configuration, it
-     * either logs the error or terminates the execution by throwing a RuntimeException.
+     * Handles an exception with a custom message. The error is always logged; afterwards the JVM
+     * is halted if {@code exitOnError} is set (the default), otherwise the throwable is rethrown
+     * so callers (e.g. tests) can observe it.
      *
      * @param msg the custom message to log along with the exception
      * @param t the throwable to handle
@@ -61,6 +62,16 @@ public class ErrorHandler {
         msg = "[SWAT Exception]: " + msg + " (at instruction: " + instCnt + ")";
         logException(msg, t);
         logger.error(msg);
+        if (!config.isExitOnError()) {
+            logger.error("Rethrowing error (exitOnError=false)...");
+            if (t instanceof RuntimeException) {
+                throw (RuntimeException) t;
+            }
+            if (t instanceof Error) {
+                throw (Error) t;
+            }
+            throw new RuntimeException(msg, t);
+        }
         logger.error("Preparing to halt execution due to error...");
         try {
             if (ThreadHandler.hasThreadContext(currentThread().getId())) {

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/config/Config.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/config/Config.java
@@ -200,6 +200,10 @@ public class Config {
     @Getter private CoverageType coverageType;
     @Getter private boolean constraintsOnly;
 
+    /** Determines whether an unrecoverable error halts the JVM or rethrows the cause. */
+    @Getter private boolean exitOnError;
+    private static final boolean DEFAULT_EXIT_ON_ERROR = true;
+
     @Getter private boolean useAbortTimer;
     private static final boolean DEFAULT_USE_ABORT_TIMER = false;
     @Getter private int abortTimerValInMS;
@@ -419,6 +423,7 @@ public class Config {
         coverageType = CoverageType.valueOf(readString("coverageType", CoverageType.NONE.name()).toUpperCase());
         coverageOnly = readBoolean("coverageOnly", false);
         constraintsOnly = readBoolean("constraintsOnly", false);
+        exitOnError = readBoolean("exitOnError", DEFAULT_EXIT_ON_ERROR);
         useAbortTimer = readBoolean("useAbortTimer", DEFAULT_USE_ABORT_TIMER);
         abortTimerValInMS = readInt("abortTimerValInMS", DEFAULT_ABORT_TIMER_VAL_IN_MS);
 

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/DoubleValue.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/DoubleValue.java
@@ -228,7 +228,8 @@ public class DoubleValue extends NumericalValue<FloatingPointFormula, Double> {
             c = nanResult;
         } else if (concrete > f.concrete) {
             c = 1;
-        } else if (concrete == f.concrete) {
+        } else if (concrete.doubleValue() == f.concrete.doubleValue()) {
+            // Explicit unboxing: 'concrete' is a boxed Double, so '==' would compare references
             c = 0;
         } else {
             c = -1;
@@ -383,23 +384,9 @@ public class DoubleValue extends NumericalValue<FloatingPointFormula, Double> {
      */
     @Override
     public ByteValue asByteValue() {
-        BooleanFormulaManager bmgr = context.getFormulaManager().getBooleanFormulaManager();
-
-        // double → int using fpToIntFormula (avoids UF in castTo)
-        NumeralFormula.IntegerFormula intFormula = fpToIntFormula(formula, 32);
-
-        // int → byte
-        NumeralFormula.IntegerFormula mod256 = imgr.modulo(intFormula, imgr.makeNumber(256));
-
-        // Adjust for signed byte: if result >= 128, subtract 256 to get negative value
-        BooleanFormula isNegative = imgr.greaterOrEquals(mod256, imgr.makeNumber(128));
-        NumeralFormula.IntegerFormula byteFormula = bmgr.ifThenElse(
-                isNegative,
-                imgr.subtract(mod256, imgr.makeNumber(256)),
-                mod256
-        );
-
-        return new ByteValue(context, concrete.byteValue(), byteFormula);
+        // d2b is d2i followed by i2b (JVM Spec 2.8 / 2.11.4); staying in bitvector
+        // theory keeps the formula tractable (integer modulo mixed with FP is not)
+        return D2I().I2B();
     }
 
     /**
@@ -411,25 +398,9 @@ public class DoubleValue extends NumericalValue<FloatingPointFormula, Double> {
      */
     @Override
     public ShortValue asShortValue() {
-
-        // double → int using fpToIntFormula (avoids UF in castTo)
-        NumeralFormula.IntegerFormula intFormula = fpToIntFormula(formula, 32);
-
-        // int → short
-        short shortVal = (short) concrete.intValue();
-
-        NumeralFormula.IntegerFormula mod65536 = imgr.modulo(intFormula, imgr.makeNumber(65536));
-
-        // Adjust to signed short range: if > 32767, subtract 65536
-        BooleanFormulaManager bmgr = context.getFormulaManager().getBooleanFormulaManager();
-        BooleanFormula isGreaterThan32767 = imgr.greaterThan(mod65536, imgr.makeNumber(32767));
-        NumeralFormula.IntegerFormula shortFormula = bmgr.ifThenElse(
-            isGreaterThan32767,
-            imgr.subtract(mod65536, imgr.makeNumber(65536)),
-            mod65536
-        );
-
-        return new ShortValue(context, shortVal, shortFormula);
+        // d2s is d2i followed by i2s (JVM Spec 2.8 / 2.11.4); staying in bitvector
+        // theory keeps the formula tractable (integer modulo mixed with FP is not)
+        return D2I().I2S();
     }
 
      /**
@@ -441,17 +412,9 @@ public class DoubleValue extends NumericalValue<FloatingPointFormula, Double> {
      */
     @Override
     public CharValue asCharValue() {
-
-        // double → int using fpToIntFormula (avoids UF in castTo)
-        NumeralFormula.IntegerFormula intFormula = fpToIntFormula(formula, 32);
-
-        // int → char 
-        char charVal = (char) concrete.intValue();
-
-        // modulo 65536 for unsigned 16-bit
-        NumeralFormula.IntegerFormula charFormula = imgr.modulo(intFormula, imgr.makeNumber(65536));
-
-        return new CharValue(context, charVal, charFormula);
+        // d2c is d2i followed by i2c (JVM Spec 2.8 / 2.11.4); staying in bitvector
+        // theory keeps the formula tractable (integer modulo mixed with FP is not)
+        return D2I().I2C();
     }
 
     @Override

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/DoubleValue.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/DoubleValue.java
@@ -384,8 +384,6 @@ public class DoubleValue extends NumericalValue<FloatingPointFormula, Double> {
      */
     @Override
     public ByteValue asByteValue() {
-        // d2b is d2i followed by i2b (JVM Spec 2.8 / 2.11.4); staying in bitvector
-        // theory keeps the formula tractable (integer modulo mixed with FP is not)
         return D2I().I2B();
     }
 
@@ -398,8 +396,6 @@ public class DoubleValue extends NumericalValue<FloatingPointFormula, Double> {
      */
     @Override
     public ShortValue asShortValue() {
-        // d2s is d2i followed by i2s (JVM Spec 2.8 / 2.11.4); staying in bitvector
-        // theory keeps the formula tractable (integer modulo mixed with FP is not)
         return D2I().I2S();
     }
 
@@ -412,8 +408,6 @@ public class DoubleValue extends NumericalValue<FloatingPointFormula, Double> {
      */
     @Override
     public CharValue asCharValue() {
-        // d2c is d2i followed by i2c (JVM Spec 2.8 / 2.11.4); staying in bitvector
-        // theory keeps the formula tractable (integer modulo mixed with FP is not)
         return D2I().I2C();
     }
 

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/FloatValue.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/FloatValue.java
@@ -332,8 +332,6 @@ public class FloatValue extends NumericalValue<FloatingPointFormula, Float> {
      * @return The resulting ByteValue
      */
     public ByteValue asByteValue() {
-        // f2b is f2i followed by i2b (JVM Spec 2.8 / 2.11.4); staying in bitvector
-        // theory keeps the formula tractable (integer modulo mixed with FP is not)
         return F2I().I2B();
     }
 
@@ -346,8 +344,6 @@ public class FloatValue extends NumericalValue<FloatingPointFormula, Float> {
      */
     @Override
     public ShortValue asShortValue() {
-        // f2s is f2i followed by i2s (JVM Spec 2.8 / 2.11.4); staying in bitvector
-        // theory keeps the formula tractable (integer modulo mixed with FP is not)
         return F2I().I2S();
     }
 
@@ -382,8 +378,6 @@ public class FloatValue extends NumericalValue<FloatingPointFormula, Float> {
      */
     @Override
     public CharValue asCharValue() {
-        // f2c is f2i followed by i2c (JVM Spec 2.8 / 2.11.4); staying in bitvector
-        // theory keeps the formula tractable (integer modulo mixed with FP is not)
         return F2I().I2C();
     }
 

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/FloatValue.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/primitive/numeric/floatingpoint/FloatValue.java
@@ -332,25 +332,9 @@ public class FloatValue extends NumericalValue<FloatingPointFormula, Float> {
      * @return The resulting ByteValue
      */
     public ByteValue asByteValue() {
-        // Step 1: float → int using fpToIntFormula (eliminates UF)
-        NumeralFormula.IntegerFormula intFormula = fpToIntFormula(formula, 32);
-
-        // Step 2: int → byte 
-        byte byteVal = (byte) concrete.intValue();
-
-        // Java byte is signed: -128 to 127
-        NumeralFormula.IntegerFormula mod256 = imgr.modulo(intFormula, imgr.makeNumber(256));
-
-        // Adjust to signed byte range: if > 127, subtract 256
-        BooleanFormulaManager bmgr = context.getFormulaManager().getBooleanFormulaManager();
-        BooleanFormula isGreaterThan127 = imgr.greaterThan(mod256, imgr.makeNumber(127));
-        NumeralFormula.IntegerFormula byteFormula = bmgr.ifThenElse(
-            isGreaterThan127,
-            imgr.subtract(mod256, imgr.makeNumber(256)),
-            mod256
-        );
-
-        return new ByteValue(context, byteVal, byteFormula);
+        // f2b is f2i followed by i2b (JVM Spec 2.8 / 2.11.4); staying in bitvector
+        // theory keeps the formula tractable (integer modulo mixed with FP is not)
+        return F2I().I2B();
     }
 
     /**
@@ -362,26 +346,9 @@ public class FloatValue extends NumericalValue<FloatingPointFormula, Float> {
      */
     @Override
     public ShortValue asShortValue() {
-
-        // float → int 
-        NumeralFormula.IntegerFormula intFormula = fpToIntFormula(formula, 32);
-
-        // int → short 
-        short shortVal = (short) concrete.intValue();
-
-        // Java short is signed: -32768 to 32767
-        NumeralFormula.IntegerFormula mod65536 = imgr.modulo(intFormula, imgr.makeNumber(65536));
-
-        // Adjust to signed short range: if > 32767, subtract 65536
-        BooleanFormulaManager bmgr = context.getFormulaManager().getBooleanFormulaManager();
-        BooleanFormula isGreaterThan32767 = imgr.greaterThan(mod65536, imgr.makeNumber(32767));
-        NumeralFormula.IntegerFormula shortFormula = bmgr.ifThenElse(
-            isGreaterThan32767,
-            imgr.subtract(mod65536, imgr.makeNumber(65536)),
-            mod65536
-        );
-
-        return new ShortValue(context, shortVal, shortFormula);
+        // f2s is f2i followed by i2s (JVM Spec 2.8 / 2.11.4); staying in bitvector
+        // theory keeps the formula tractable (integer modulo mixed with FP is not)
+        return F2I().I2S();
     }
 
     /**
@@ -415,17 +382,9 @@ public class FloatValue extends NumericalValue<FloatingPointFormula, Float> {
      */
     @Override
     public CharValue asCharValue() {
-
-        // Step 1: float → int using fpToIntFormula (eliminates UF)
-        NumeralFormula.IntegerFormula intFormula = fpToIntFormula(formula, 32);
-
-        // Step 2: int → char 
-        char charVal = (char) concrete.intValue();
-
-        // modulo 65536 for unsigned 16-bit
-        NumeralFormula.IntegerFormula charFormula = imgr.modulo(intFormula, imgr.makeNumber(65536));
-
-        return new CharValue(context, charVal, charFormula);
+        // f2c is f2i followed by i2c (JVM Spec 2.8 / 2.11.4); staying in bitvector
+        // theory keeps the formula tractable (integer modulo mixed with FP is not)
+        return F2I().I2C();
     }
 
     @Override

--- a/symbolic-executor/src/test/groovy/de/uzl/its/swat/symbolic/processor/BaseSymbolicInstructionProcessorSpec.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/swat/symbolic/processor/BaseSymbolicInstructionProcessorSpec.groovy
@@ -34,6 +34,8 @@ import de.uzl.its.swat.symbolic.value.reference.lang.StringValue
 import de.uzl.its.swat.thread.ThreadHandler
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
 import de.uzl.its.swat.common.Util
 import de.uzl.its.swat.symbolic.value.primitive.numeric.integral.IntValue
 import de.uzl.its.swat.symbolic.value.primitive.numeric.integral.ShortValue
@@ -43,12 +45,18 @@ abstract class BaseSymbolicInstructionProcessorSpec extends Specification {
     protected final threadId = Thread.currentThread().getId()
     protected SolverContext solverContext
     protected static final Logger logger = GlobalLogger.getSymbolicExecutionLogger();
+    private static final AtomicInteger methodNameCounter = new AtomicInteger()
 
     /**
      * Initializes a clean thread context, registers the test class/method in the instrumentation
      * system, and sets up an initial frame in the shadow context.
      */
     def setupTestContext(String testClassName, String testMethodName, String testDesc = "()V") {
+        // Make the method name unique per test: GlobalStateForInstrumentation resets its
+        // per-method instruction counter on setCid/setMid but tracks seen instruction IDs
+        // globally, so re-instrumenting the same (class, method) across tests would produce
+        // duplicate instruction IDs.
+        testMethodName = testMethodName + "\$test" + methodNameCounter.incrementAndGet()
         Config config = Config.instance()
         config.setLogShadowStateToConsole(true)
         // Clean up any existing context for this thread.
@@ -67,6 +75,7 @@ abstract class BaseSymbolicInstructionProcessorSpec extends Specification {
         GlobalStateForInstrumentation.instance.setCid(classIndex)
         ClassDepot.getInstrumentationInstance().registerTypeInfoForClass(testClassName, ["java.lang.Object"], new ArrayList<>())
         int methodIdx = classDepot.getMethodIdxForInstrumentation(testClassName, testMethodName, testDesc)
+        GlobalStateForInstrumentation.instance.setMid(methodIdx)
         SymbolicInstructionVisitor visitor = ThreadHandler.getSymbolicVisitor(threadId)
         ShadowContext context = visitor.getStack()
         Frame frame = new Frame(testClassName, testMethodName, methodIdx)

--- a/symbolic-executor/src/test/groovy/de/uzl/its/swat/testsupport/EagerFailureRenderingExtension.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/swat/testsupport/EagerFailureRenderingExtension.groovy
@@ -1,0 +1,59 @@
+package de.uzl.its.swat.testsupport
+
+import org.spockframework.runtime.extension.IGlobalExtension
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.SpecInfo
+
+/**
+ * Forces Spock failure messages to be rendered while the failing test's
+ * resources are still alive.
+ *
+ * Spock renders condition failures lazily: the values captured in a failed
+ * condition (e.g. an IntValue) are only stringified when the test framework
+ * asks for the exception message, which Gradle does AFTER the spec's
+ * cleanup() has run. Our value specs close their Z3 SolverContext in
+ * cleanup(), and calling formula.toString() on a closed context makes the
+ * native Z3 library abort the whole test JVM (assertion violation in
+ * api_ast.cpp), discarding all test reports.
+ *
+ * This extension intercepts every feature method and, when it throws,
+ * touches getMessage() on the entire throwable chain before the error
+ * propagates. Spock caches the rendering on first access, so the later,
+ * post-cleanup message lookups reuse the already-rendered string instead of
+ * calling back into the solver.
+ */
+class EagerFailureRenderingExtension implements IGlobalExtension {
+
+    private static final IMethodInterceptor EAGER_RENDER = { IMethodInvocation invocation ->
+        try {
+            invocation.proceed()
+        } catch (Throwable t) {
+            forceRender(t)
+            throw t
+        }
+    } as IMethodInterceptor
+
+    private static void forceRender(Throwable t) {
+        Set<Throwable> seen = ([] as Set).asSynchronized()
+        List<Throwable> queue = [t]
+        while (!queue.isEmpty()) {
+            Throwable cur = queue.removeLast()
+            if (cur == null || !seen.add(cur)) {
+                continue
+            }
+            try {
+                cur.getMessage()
+            } catch (Throwable ignored) {
+                // Rendering must never mask the original failure
+            }
+            queue.add(cur.getCause())
+            queue.addAll(cur.getSuppressed())
+        }
+    }
+
+    @Override
+    void visitSpec(SpecInfo spec) {
+        spec.allFeatures*.featureMethod*.addInterceptor(EAGER_RENDER)
+    }
+}

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/floatingpoint/DoubleValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/floatingpoint/DoubleValueTest.groovy
@@ -5,10 +5,10 @@ import org.sosy_lab.common.ShutdownManager
 import org.sosy_lab.common.configuration.Configuration
 import org.sosy_lab.common.log.BasicLogManager
 import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager
 import org.sosy_lab.java_smt.api.BooleanFormulaManager
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager
 import org.sosy_lab.java_smt.api.FormulaManager
-import org.sosy_lab.java_smt.api.IntegerFormulaManager
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Shared
@@ -21,7 +21,7 @@ class DoubleValueTest extends Specification {
     ProverEnvironment prover
     FormulaManager fmgr
     BooleanFormulaManager bmgr
-    IntegerFormulaManager imgr
+    BitvectorFormulaManager bvmgr
     FloatingPointFormulaManager fpmgr
 
     def setup() {
@@ -35,7 +35,7 @@ class DoubleValueTest extends Specification {
                 SolverContext.ProverOptions.GENERATE_MODELS)
         fmgr = context.getFormulaManager()
         bmgr = fmgr.getBooleanFormulaManager()
-        imgr = fmgr.getIntegerFormulaManager()
+        bvmgr = fmgr.getBitvectorFormulaManager()
         fpmgr = fmgr.getFloatingPointFormulaManager()
     }
 
@@ -248,7 +248,7 @@ class DoubleValueTest extends Specification {
         when:
 
         def i1 = d1.DCMPG(d2)
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
         then:
         !prover.isUnsat()
         noExceptionThrown()
@@ -274,7 +274,7 @@ class DoubleValueTest extends Specification {
         when:
 
         def i1 = d1.DCMPL(d2)
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
         then:
         !prover.isUnsat()
         noExceptionThrown()
@@ -298,7 +298,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def i1 = d1.D2I()
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
         then:
         !prover.isUnsat()
         i1.concrete == res
@@ -336,7 +336,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def l1 = d1.D2L()
-        prover.addConstraint(imgr.equal(l1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(l1.formula, bvmgr.makeBitvector(64, res)))
         then:
         !prover.isUnsat()
         l1.concrete == res
@@ -357,7 +357,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def i1 = d1.D2I()
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 
         then:
         !prover.isUnsat()
@@ -382,7 +382,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def i1 = d1.D2I()
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 
         then:
         !prover.isUnsat()
@@ -410,7 +410,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def i1 = d1.D2I()
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 
         then:
         !prover.isUnsat()
@@ -430,7 +430,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def i1 = d1.D2I()
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 
         then:
         !prover.isUnsat()
@@ -452,7 +452,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def i1 = d1.D2I()
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 
         then:
         !prover.isUnsat()
@@ -476,8 +476,8 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(10.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(100.0d, DoubleValue.precision)))
         // Constrain: 10 <= i <= 100
-        prover.addConstraint(imgr.greaterOrEquals(i1.formula, imgr.makeNumber(10)))
-        prover.addConstraint(imgr.lessOrEquals(i1.formula, imgr.makeNumber(100)))
+        prover.addConstraint(bvmgr.greaterOrEquals(i1.formula, bvmgr.makeBitvector(32, 10), true))
+        prover.addConstraint(bvmgr.lessOrEquals(i1.formula, bvmgr.makeBitvector(32, 100), true))
 
         then:
         // Should be SAT: values in [10, 100] map to integers in [10, 100]
@@ -495,7 +495,7 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(10.5d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(11.5d, DoubleValue.precision)))
         // Constrain: i must be exactly 11
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(11)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, 11)))
 
         then:
         // Should be SAT: values in [10.5, 11.5] truncate to 10 or 11
@@ -514,7 +514,7 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(10.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(20.0d, DoubleValue.precision)))
         // But require: i > 1000 (impossible!)
-        prover.addConstraint(imgr.greaterThan(i1.formula, imgr.makeNumber(1000)))
+        prover.addConstraint(bvmgr.greaterThan(i1.formula, bvmgr.makeBitvector(32, 1000), true))
 
         def isUnsat = prover.isUnsat()
         if (!isUnsat) {
@@ -547,7 +547,7 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(-100.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(-1.0d, DoubleValue.precision)))
         // But require: i > 0 (positive integer - impossible!)
-        prover.addConstraint(imgr.greaterThan(i1.formula, imgr.makeNumber(0)))
+        prover.addConstraint(bvmgr.greaterThan(i1.formula, bvmgr.makeBitvector(32, 0), true))
 
         def isUnsat = prover.isUnsat()
         if (!isUnsat) {
@@ -579,8 +579,8 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(40.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(60.0d, DoubleValue.precision)))
         // Require: 40 <= i <= 60
-        prover.addConstraint(imgr.greaterOrEquals(i1.formula, imgr.makeNumber(40)))
-        prover.addConstraint(imgr.lessOrEquals(i1.formula, imgr.makeNumber(60)))
+        prover.addConstraint(bvmgr.greaterOrEquals(i1.formula, bvmgr.makeBitvector(32, 40), true))
+        prover.addConstraint(bvmgr.lessOrEquals(i1.formula, bvmgr.makeBitvector(32, 60), true))
 
         then:
         // Should be SAT: ranges match
@@ -598,7 +598,7 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterThan(d1.formula, fpmgr.makeNumber(10.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessThan(d1.formula, fpmgr.makeNumber(11.0d, DoubleValue.precision)))
         // Require: i == 10
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(10)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, 10)))
 
         then:
         // Should be SAT: (10.0, 11.0) truncates to 10
@@ -616,7 +616,7 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterThan(d1.formula, fpmgr.makeNumber(10.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessThan(d1.formula, fpmgr.makeNumber(11.0d, DoubleValue.precision)))
         // But require: i == 11 (impossible - values in (10,11) can't truncate to 11)
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(11)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, 11)))
 
         def isUnsat = prover.isUnsat()
         if (!isUnsat) {
@@ -640,7 +640,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def b1 = d1.asByteValue()
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
         then:
         !prover.isUnsat()
@@ -663,7 +663,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def b1 = d1.asByteValue()
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
         then:
         !prover.isUnsat()
@@ -686,7 +686,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def b1 = d1.asByteValue()
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
         then:
         !prover.isUnsat()
@@ -707,7 +707,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def b1 = d1.asByteValue()
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
         then:
         !prover.isUnsat()
@@ -728,7 +728,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def b1 = d1.asByteValue()
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
         then:
         !prover.isUnsat()
@@ -756,8 +756,8 @@ class DoubleValueTest extends Specification {
         when:
         def b1 = d1.asByteValue()
         // Constraint: byte value should be in range [1, 127] (positive bytes)
-        prover.addConstraint(imgr.greaterThan(b1.formula, imgr.makeNumber(0)))
-        prover.addConstraint(imgr.lessOrEquals(b1.formula, imgr.makeNumber(127)))
+        prover.addConstraint(bvmgr.greaterThan(b1.formula, bvmgr.makeBitvector(8, 0), true))
+        prover.addConstraint(bvmgr.lessOrEquals(b1.formula, bvmgr.makeBitvector(8, 127), true))
         // Original double should be in [1, 127] range (should map to positive bytes)
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(1.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(127.0d, DoubleValue.precision)))
@@ -775,7 +775,7 @@ class DoubleValueTest extends Specification {
         when:
         def b1 = d1.asByteValue()
         // Add constraint that the byte value should be greater than 0
-        prover.addConstraint(imgr.greaterThan(b1.formula, imgr.makeNumber(0)))
+        prover.addConstraint(bvmgr.greaterThan(b1.formula, bvmgr.makeBitvector(8, 0), true))
         // But constrain the original double to be in range [128, 256)
         // Values in this range wrap to negative bytes, so this should be UNSAT
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(128.0d, DoubleValue.precision)))
@@ -805,8 +805,8 @@ class DoubleValueTest extends Specification {
         when:
         def b1 = d1.asByteValue()
         // Constraint: byte value should be in range [-128, -1]
-        prover.addConstraint(imgr.greaterOrEquals(b1.formula, imgr.makeNumber(-128)))
-        prover.addConstraint(imgr.lessOrEquals(b1.formula, imgr.makeNumber(-1)))
+        prover.addConstraint(bvmgr.greaterOrEquals(b1.formula, bvmgr.makeBitvector(8, -128), true))
+        prover.addConstraint(bvmgr.lessOrEquals(b1.formula, bvmgr.makeBitvector(8, -1), true))
         // Original double should be in [128, 255] (after truncation gives values that wrap to negative bytes)
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(128.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessThan(d1.formula, fpmgr.makeNumber(256.0d, DoubleValue.precision)))
@@ -826,7 +826,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def s1 = d1.asShortValue()
-        prover.addConstraint(imgr.equal(s1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(s1.formula, bvmgr.makeBitvector(16, res)))
 
         then:
         !prover.isUnsat()
@@ -853,7 +853,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def s1 = d1.asShortValue()
-        prover.addConstraint(imgr.equal(s1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(s1.formula, bvmgr.makeBitvector(16, res)))
 
         then:
         !prover.isUnsat()
@@ -877,7 +877,7 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(100.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(200.0d, DoubleValue.precision)))
         // But require short > 10000 (impossible!)
-        prover.addConstraint(imgr.greaterThan(s1.formula, imgr.makeNumber(10000)))
+        prover.addConstraint(bvmgr.greaterThan(s1.formula, bvmgr.makeBitvector(16, 10000), true))
 
         then:
         prover.isUnsat()
@@ -894,8 +894,8 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(500.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(2000.0d, DoubleValue.precision)))
         // Require short in valid range (500-2000)
-        prover.addConstraint(imgr.greaterOrEquals(s1.formula, imgr.makeNumber(500)))
-        prover.addConstraint(imgr.lessOrEquals(s1.formula, imgr.makeNumber(2000)))
+        prover.addConstraint(bvmgr.greaterOrEquals(s1.formula, bvmgr.makeBitvector(16, 500), true))
+        prover.addConstraint(bvmgr.lessOrEquals(s1.formula, bvmgr.makeBitvector(16, 2000), true))
 
         then:
         !prover.isUnsat()
@@ -907,7 +907,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def ch1 = d1.asCharValue()
-        prover.addConstraint(imgr.equal(ch1.formula, imgr.makeNumber((int)res)))
+        prover.addConstraint(bvmgr.equal(ch1.formula, bvmgr.makeBitvector(16, (int)res)))
 
         then:
         !prover.isUnsat()
@@ -932,7 +932,7 @@ class DoubleValueTest extends Specification {
 
         when:
         def ch1 = d1.asCharValue()
-        prover.addConstraint(imgr.equal(ch1.formula, imgr.makeNumber((int)res)))
+        prover.addConstraint(bvmgr.equal(ch1.formula, bvmgr.makeBitvector(16, (int)res)))
 
         then:
         !prover.isUnsat()
@@ -956,8 +956,8 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(65.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(90.0d, DoubleValue.precision)))
         // Require char in valid range (65-90, 'A'-'Z')
-        prover.addConstraint(imgr.greaterOrEquals(ch1.formula, imgr.makeNumber(65)))
-        prover.addConstraint(imgr.lessOrEquals(ch1.formula, imgr.makeNumber(90)))
+        prover.addConstraint(bvmgr.greaterOrEquals(ch1.formula, bvmgr.makeBitvector(16, 65), false))
+        prover.addConstraint(bvmgr.lessOrEquals(ch1.formula, bvmgr.makeBitvector(16, 90), false))
 
         then:
         !prover.isUnsat()
@@ -974,7 +974,7 @@ class DoubleValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(d1.formula, fpmgr.makeNumber(0.0d, DoubleValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(d1.formula, fpmgr.makeNumber(100.0d, DoubleValue.precision)))
         // But require char > 1000 (impossible!)
-        prover.addConstraint(imgr.greaterThan(ch1.formula, imgr.makeNumber(1000)))
+        prover.addConstraint(bvmgr.greaterThan(ch1.formula, bvmgr.makeBitvector(16, 1000), false))
 
         then:
         prover.isUnsat()

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/floatingpoint/DoubleValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/floatingpoint/DoubleValueTest.groovy
@@ -748,6 +748,25 @@ class DoubleValueTest extends Specification {
         128.1d   || (byte) -128
     }
 
+    def "asByteValue - special values"(double c1, byte res) {
+        given:
+        def d1 = new DoubleValue(context, c1)
+
+        when:
+        def b1 = d1.asByteValue()
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
+
+        then:
+        !prover.isUnsat()
+        b1.concrete == res
+
+        where:
+        c1                          || res
+        Double.NaN                  || (byte) 0
+        Double.POSITIVE_INFINITY    || (byte) -1   // Integer.MAX_VALUE wraps to byte
+        Double.NEGATIVE_INFINITY    || (byte) 0    // Integer.MIN_VALUE wraps to byte
+    }
+
     def "asByteValue - symbolic constraint satisfaction"() {
         given:
         def d1 = new DoubleValue(context, 10.0d)

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/floatingpoint/FloatValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/floatingpoint/FloatValueTest.groovy
@@ -6,10 +6,10 @@ import org.sosy_lab.common.ShutdownManager
 import org.sosy_lab.common.configuration.Configuration
 import org.sosy_lab.common.log.BasicLogManager
 import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager
 import org.sosy_lab.java_smt.api.BooleanFormulaManager
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager
 import org.sosy_lab.java_smt.api.FormulaManager
-import org.sosy_lab.java_smt.api.IntegerFormulaManager
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Shared
@@ -21,7 +21,7 @@ class FloatValueTest extends Specification {
     ProverEnvironment prover
     FormulaManager fmgr
     BooleanFormulaManager bmgr
-    IntegerFormulaManager imgr
+    BitvectorFormulaManager bvmgr
     FloatingPointFormulaManager fpmgr
 
     def setup() {
@@ -35,7 +35,7 @@ class FloatValueTest extends Specification {
                 SolverContext.ProverOptions.GENERATE_MODELS)
         fmgr = context.getFormulaManager()
         bmgr = fmgr.getBooleanFormulaManager()
-        imgr = fmgr.getIntegerFormulaManager()
+        bvmgr = fmgr.getBitvectorFormulaManager()
         fpmgr = fmgr.getFloatingPointFormulaManager()
     }
 
@@ -232,7 +232,7 @@ class FloatValueTest extends Specification {
 
         when:
         def i1 = f1.F2I()
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 
         then:
         !prover.isUnsat()
@@ -274,7 +274,7 @@ class FloatValueTest extends Specification {
 
         when:
         def l1 = f1.F2L()
-        prover.addConstraint(imgr.equal(l1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(l1.formula, bvmgr.makeBitvector(64, res)))
 
         then:
         !prover.isUnsat()
@@ -295,7 +295,7 @@ class FloatValueTest extends Specification {
         when:
 
         def i1 = f1.FCMPG(f2)
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
         then:
         !prover.isUnsat()
         noExceptionThrown()
@@ -321,7 +321,7 @@ class FloatValueTest extends Specification {
         when:
 
         def i1 = f1.FCMPL(f2)
-        prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
         then:
         !prover.isUnsat()
         noExceptionThrown()
@@ -347,7 +347,7 @@ class FloatValueTest extends Specification {
 
         when:
         def b1 = f1.asByteValue()
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
         then:
         !prover.isUnsat()
@@ -372,7 +372,7 @@ class FloatValueTest extends Specification {
 
         when:
         def b1 = f1.asByteValue()
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
         then:
         !prover.isUnsat()
@@ -396,7 +396,7 @@ class FloatValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(f1.formula, fpmgr.makeNumber(10.0f, FloatValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(f1.formula, fpmgr.makeNumber(20.0f, FloatValue.precision)))
         // But require byte > 100 (impossible!)
-        prover.addConstraint(imgr.greaterThan(b1.formula, imgr.makeNumber(100)))
+        prover.addConstraint(bvmgr.greaterThan(b1.formula, bvmgr.makeBitvector(8, 100), true))
 
         then:
         prover.isUnsat()
@@ -408,7 +408,7 @@ class FloatValueTest extends Specification {
 
         when:
         def s1 = f1.asShortValue()
-        prover.addConstraint(imgr.equal(s1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(s1.formula, bvmgr.makeBitvector(16, res)))
 
         then:
         !prover.isUnsat()
@@ -433,7 +433,7 @@ class FloatValueTest extends Specification {
 
         when:
         def s1 = f1.asShortValue()
-        prover.addConstraint(imgr.equal(s1.formula, imgr.makeNumber(res)))
+        prover.addConstraint(bvmgr.equal(s1.formula, bvmgr.makeBitvector(16, res)))
 
         then:
         !prover.isUnsat()
@@ -457,7 +457,7 @@ class FloatValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(f1.formula, fpmgr.makeNumber(100.0f, FloatValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(f1.formula, fpmgr.makeNumber(200.0f, FloatValue.precision)))
         // But require short > 10000 (impossible!)
-        prover.addConstraint(imgr.greaterThan(s1.formula, imgr.makeNumber(10000)))
+        prover.addConstraint(bvmgr.greaterThan(s1.formula, bvmgr.makeBitvector(16, 10000), true))
 
         then:
         prover.isUnsat()
@@ -469,7 +469,7 @@ class FloatValueTest extends Specification {
 
         when:
         def ch1 = f1.asCharValue()
-        prover.addConstraint(imgr.equal(ch1.formula, imgr.makeNumber((int)res)))
+        prover.addConstraint(bvmgr.equal(ch1.formula, bvmgr.makeBitvector(16, (int)res)))
 
         then:
         !prover.isUnsat()
@@ -492,7 +492,7 @@ class FloatValueTest extends Specification {
 
         when:
         def ch1 = f1.asCharValue()
-        prover.addConstraint(imgr.equal(ch1.formula, imgr.makeNumber((int)res)))
+        prover.addConstraint(bvmgr.equal(ch1.formula, bvmgr.makeBitvector(16, (int)res)))
 
         then:
         !prover.isUnsat()
@@ -516,8 +516,8 @@ class FloatValueTest extends Specification {
         prover.addConstraint(fpmgr.greaterOrEquals(f1.formula, fpmgr.makeNumber(65.0f, FloatValue.precision)))
         prover.addConstraint(fpmgr.lessOrEquals(f1.formula, fpmgr.makeNumber(90.0f, FloatValue.precision)))
         // Require char in valid range (65-90, 'A'-'Z')
-        prover.addConstraint(imgr.greaterOrEquals(ch1.formula, imgr.makeNumber(65)))
-        prover.addConstraint(imgr.lessOrEquals(ch1.formula, imgr.makeNumber(90)))
+        prover.addConstraint(bvmgr.greaterOrEquals(ch1.formula, bvmgr.makeBitvector(16, 65), false))
+        prover.addConstraint(bvmgr.lessOrEquals(ch1.formula, bvmgr.makeBitvector(16, 90), false))
 
         then:
         !prover.isUnsat()

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/ByteValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/ByteValueTest.groovy
@@ -6,9 +6,9 @@ import org.sosy_lab.common.ShutdownManager
 import org.sosy_lab.common.configuration.Configuration
 import org.sosy_lab.common.log.BasicLogManager
 import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager
 import org.sosy_lab.java_smt.api.BooleanFormulaManager
 import org.sosy_lab.java_smt.api.FormulaManager
-import org.sosy_lab.java_smt.api.IntegerFormulaManager
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Specification
@@ -19,7 +19,7 @@ class ByteValueTest extends Specification {
     ProverEnvironment prover
     FormulaManager fmgr
     BooleanFormulaManager bmgr
-    IntegerFormulaManager imgr
+    BitvectorFormulaManager bvmgr
 
     def setup() {
         context = SolverContextFactory.createSolverContext(
@@ -31,7 +31,7 @@ class ByteValueTest extends Specification {
                 SolverContext.ProverOptions.GENERATE_MODELS)
         fmgr = context.getFormulaManager()
         bmgr = fmgr.getBooleanFormulaManager()
-        imgr = fmgr.getIntegerFormulaManager()
+        bvmgr = fmgr.getBitvectorFormulaManager()
     }
 
     def cleanup() {
@@ -71,10 +71,10 @@ class ByteValueTest extends Specification {
         when:
         def c1 = b1.asCharValue()
         // Constrain byte: 10 <= b <= 100
-        prover.addConstraint(imgr.greaterOrEquals(b1.formula, imgr.makeNumber(10)))
-        prover.addConstraint(imgr.lessOrEquals(b1.formula, imgr.makeNumber(100)))
+        prover.addConstraint(bvmgr.greaterOrEquals(b1.formula, bvmgr.makeBitvector(8, 10), true))
+        prover.addConstraint(bvmgr.lessOrEquals(b1.formula, bvmgr.makeBitvector(8, 100), true))
         // Require char == 50 (possible!)
-        prover.addConstraint(imgr.equal(c1.formula, imgr.makeNumber(50)))
+        prover.addConstraint(bvmgr.equal(c1.formula, bvmgr.makeBitvector(16, 50)))
 
         then:
         !prover.isUnsat()
@@ -89,10 +89,10 @@ class ByteValueTest extends Specification {
         when:
         def c1 = b1.asCharValue()
         // Constrain byte: -100 <= b <= -10
-        prover.addConstraint(imgr.greaterOrEquals(b1.formula, imgr.makeNumber(-100)))
-        prover.addConstraint(imgr.lessOrEquals(b1.formula, imgr.makeNumber(-10)))
+        prover.addConstraint(bvmgr.greaterOrEquals(b1.formula, bvmgr.makeBitvector(8, -100), true))
+        prover.addConstraint(bvmgr.lessOrEquals(b1.formula, bvmgr.makeBitvector(8, -10), true))
         // Negative bytes should map to high char values (> 65000)
-        prover.addConstraint(imgr.greaterThan(c1.formula, imgr.makeNumber(65000)))
+        prover.addConstraint(bvmgr.greaterThan(c1.formula, bvmgr.makeBitvector(16, 65000), false))
 
         then:
         !prover.isUnsat()
@@ -107,10 +107,10 @@ class ByteValueTest extends Specification {
         when:
         def c1 = b1.asCharValue()
         // Constrain byte to be negative: -100 <= b <= -10
-        prover.addConstraint(imgr.greaterOrEquals(b1.formula, imgr.makeNumber(-100)))
-        prover.addConstraint(imgr.lessOrEquals(b1.formula, imgr.makeNumber(-10)))
+        prover.addConstraint(bvmgr.greaterOrEquals(b1.formula, bvmgr.makeBitvector(8, -100), true))
+        prover.addConstraint(bvmgr.lessOrEquals(b1.formula, bvmgr.makeBitvector(8, -10), true))
         // But require char < 1000 (impossible - negative bytes map to high chars!)
-        prover.addConstraint(imgr.lessThan(c1.formula, imgr.makeNumber(1000)))
+        prover.addConstraint(bvmgr.lessThan(c1.formula, bvmgr.makeBitvector(16, 1000), false))
 
         then:
         prover.isUnsat()
@@ -123,8 +123,8 @@ class ByteValueTest extends Specification {
 
         when:
         def c1 = b1.asCharValue()
-        // Add constraint that formula equals the concrete value (cast char to int for makeNumber)
-        prover.addConstraint(imgr.equal(c1.formula, imgr.makeNumber((int) ((char) c1.concrete))))
+        // Add constraint that formula equals the concrete value (cast char to int for makeBitvector)
+        prover.addConstraint(bvmgr.equal(c1.formula, bvmgr.makeBitvector(16, (int) ((char) c1.concrete))))
 
         then:
         !prover.isUnsat()

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/CharValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/CharValueTest.groovy
@@ -7,9 +7,9 @@ import org.sosy_lab.common.ShutdownManager
 import org.sosy_lab.common.configuration.Configuration
 import org.sosy_lab.common.log.BasicLogManager
 import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager
 import org.sosy_lab.java_smt.api.BooleanFormulaManager
 import org.sosy_lab.java_smt.api.FormulaManager
-import org.sosy_lab.java_smt.api.IntegerFormulaManager
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Specification
@@ -20,7 +20,7 @@ class CharValueTest extends Specification {
     ProverEnvironment prover
     FormulaManager fmgr
     BooleanFormulaManager bmgr
-    IntegerFormulaManager imgr
+    BitvectorFormulaManager bvmgr
 
     def setup() {
         context = SolverContextFactory.createSolverContext(
@@ -32,7 +32,7 @@ class CharValueTest extends Specification {
                 SolverContext.ProverOptions.GENERATE_MODELS)
         fmgr = context.getFormulaManager()
         bmgr = fmgr.getBooleanFormulaManager()
-        imgr = fmgr.getIntegerFormulaManager()
+        bvmgr = fmgr.getBitvectorFormulaManager()
     }
 
     def cleanup() {
@@ -74,10 +74,10 @@ class CharValueTest extends Specification {
         when:
         def b1 = c1.asByteValue()
         // Constrain char: 10 <= c <= 100
-        prover.addConstraint(imgr.greaterOrEquals(c1.formula, imgr.makeNumber(10)))
-        prover.addConstraint(imgr.lessOrEquals(c1.formula, imgr.makeNumber(100)))
+        prover.addConstraint(bvmgr.greaterOrEquals(c1.formula, bvmgr.makeBitvector(16, 10), false))
+        prover.addConstraint(bvmgr.lessOrEquals(c1.formula, bvmgr.makeBitvector(16, 100), false))
         // Require byte == 50 (possible!)
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(50)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, 50)))
 
         then:
         !prover.isUnsat()
@@ -92,10 +92,10 @@ class CharValueTest extends Specification {
         when:
         def b1 = c1.asByteValue()
         // Constrain char: 10 <= c <= 20
-        prover.addConstraint(imgr.greaterOrEquals(c1.formula, imgr.makeNumber(10)))
-        prover.addConstraint(imgr.lessOrEquals(c1.formula, imgr.makeNumber(20)))
+        prover.addConstraint(bvmgr.greaterOrEquals(c1.formula, bvmgr.makeBitvector(16, 10), false))
+        prover.addConstraint(bvmgr.lessOrEquals(c1.formula, bvmgr.makeBitvector(16, 20), false))
         // But require byte > 100 (impossible!)
-        prover.addConstraint(imgr.greaterThan(b1.formula, imgr.makeNumber(100)))
+        prover.addConstraint(bvmgr.greaterThan(b1.formula, bvmgr.makeBitvector(8, 100), true))
 
         then:
         prover.isUnsat()
@@ -134,10 +134,10 @@ class CharValueTest extends Specification {
         when:
         def s1 = c1.asShortValue()
         // Constrain char: 500 <= c <= 1500
-        prover.addConstraint(imgr.greaterOrEquals(c1.formula, imgr.makeNumber(500)))
-        prover.addConstraint(imgr.lessOrEquals(c1.formula, imgr.makeNumber(1500)))
+        prover.addConstraint(bvmgr.greaterOrEquals(c1.formula, bvmgr.makeBitvector(16, 500), false))
+        prover.addConstraint(bvmgr.lessOrEquals(c1.formula, bvmgr.makeBitvector(16, 1500), false))
         // Require short == 1000 (possible!)
-        prover.addConstraint(imgr.equal(s1.formula, imgr.makeNumber(1000)))
+        prover.addConstraint(bvmgr.equal(s1.formula, bvmgr.makeBitvector(16, 1000)))
 
         then:
         !prover.isUnsat()
@@ -152,10 +152,10 @@ class CharValueTest extends Specification {
         when:
         def s1 = c1.asShortValue()
         // Constrain char to high range: 40000 <= c <= 50000
-        prover.addConstraint(imgr.greaterOrEquals(c1.formula, imgr.makeNumber(40000)))
-        prover.addConstraint(imgr.lessOrEquals(c1.formula, imgr.makeNumber(50000)))
+        prover.addConstraint(bvmgr.greaterOrEquals(c1.formula, bvmgr.makeBitvector(16, 40000), false))
+        prover.addConstraint(bvmgr.lessOrEquals(c1.formula, bvmgr.makeBitvector(16, 50000), false))
         // But require short > 0 (impossible - high chars map to negative shorts!)
-        prover.addConstraint(imgr.greaterThan(s1.formula, imgr.makeNumber(0)))
+        prover.addConstraint(bvmgr.greaterThan(s1.formula, bvmgr.makeBitvector(16, 0), true))
 
         then:
         prover.isUnsat()
@@ -170,11 +170,11 @@ class CharValueTest extends Specification {
         when:
         def s1 = c1.asShortValue()
         // Constrain char: 32760 <= c <= 32770
-        prover.addConstraint(imgr.greaterOrEquals(c1.formula, imgr.makeNumber(32760)))
-        prover.addConstraint(imgr.lessOrEquals(c1.formula, imgr.makeNumber(32770)))
+        prover.addConstraint(bvmgr.greaterOrEquals(c1.formula, bvmgr.makeBitvector(16, 32760), false))
+        prover.addConstraint(bvmgr.lessOrEquals(c1.formula, bvmgr.makeBitvector(16, 32770), false))
         // Require short in range that crosses the boundary
-        prover.addConstraint(imgr.greaterOrEquals(s1.formula, imgr.makeNumber(-32768)))
-        prover.addConstraint(imgr.lessOrEquals(s1.formula, imgr.makeNumber(32767)))
+        prover.addConstraint(bvmgr.greaterOrEquals(s1.formula, bvmgr.makeBitvector(16, -32768), true))
+        prover.addConstraint(bvmgr.lessOrEquals(s1.formula, bvmgr.makeBitvector(16, 32767), true))
 
         then:
         !prover.isUnsat()

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/IntValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/IntValueTest.groovy
@@ -7,10 +7,10 @@ import org.sosy_lab.common.ShutdownManager
 import org.sosy_lab.common.configuration.Configuration
 import org.sosy_lab.common.log.BasicLogManager
 import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager
 import org.sosy_lab.java_smt.api.BooleanFormulaManager
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager
 import org.sosy_lab.java_smt.api.FormulaManager
-import org.sosy_lab.java_smt.api.IntegerFormulaManager
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Shared
@@ -23,7 +23,7 @@ class IntValueTest extends Specification {
 	ProverEnvironment prover
 	FormulaManager fmgr
 	BooleanFormulaManager bmgr
-	IntegerFormulaManager imgr
+	BitvectorFormulaManager bvmgr
 	FloatingPointFormulaManager fpmgr
 
 	def setup() {
@@ -37,7 +37,7 @@ class IntValueTest extends Specification {
 				SolverContext.ProverOptions.GENERATE_MODELS)
 		fmgr = context.getFormulaManager()
 		bmgr = fmgr.getBooleanFormulaManager()
-		imgr = fmgr.getIntegerFormulaManager()
+		bvmgr = fmgr.getBitvectorFormulaManager()
 		fpmgr = fmgr.getFloatingPointFormulaManager()
 	}
 	def cleanup(){
@@ -84,7 +84,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.IADD(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -113,7 +113,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.ISUB(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -142,7 +142,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.IMUL(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -173,14 +173,14 @@ class IntValueTest extends Specification {
 		AssertionError e = null;
 		try {
 			i3 = i1.IDIV(i2)
-			prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+			prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 		} catch (AssertionError a) {
 			e = a
 		}
 
 		then:
 		if (c2 == 0) {
-			assert e instanceof AssertionError && e.message == "Division by zero!"
+			assert e instanceof AssertionError && e.message == "[SWAT Assertion]: Division by zero!"
 		} else {
 			assert !prover.isUnsat()
 			assert i3.concrete == res
@@ -213,7 +213,7 @@ class IntValueTest extends Specification {
 		Exception e = null;
 		try {
 			i3 = i1.IREM(i2)
-			prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+			prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 		} catch (ArithmeticException a) {
 			e = a
 		}
@@ -249,7 +249,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.INEG()
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -272,7 +272,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.IINC(c2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -300,7 +300,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.IAND(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -328,7 +328,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.ISHL(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -357,7 +357,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.ISHR(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -386,7 +386,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.IUSHR(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -415,7 +415,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.IOR(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -444,7 +444,7 @@ class IntValueTest extends Specification {
 		when:
 
 		def i3 = i1.IXOR(i2)
-		prover.addConstraint(imgr.equal(i3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i3.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -828,7 +828,7 @@ class IntValueTest extends Specification {
 
 		when:
 		def l1 = i1.I2L()
-		prover.addConstraint(imgr.equal(l1.formula,imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l1.formula,bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		(l1.concrete == res)
@@ -850,7 +850,7 @@ class IntValueTest extends Specification {
 
 		when:
 		def b1 = i1.I2B()
-		prover.addConstraint(imgr.equal(b1.formula,imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(b1.formula,bvmgr.makeBitvector(8, res)))
 		then:
 		!prover.isUnsat()
 		(b1.concrete == res)
@@ -871,7 +871,7 @@ class IntValueTest extends Specification {
 
 		when:
 		def ch1 = i1.I2C()
-		prover.addConstraint(imgr.equal(ch1.formula,imgr.makeNumber((int) res)))
+		prover.addConstraint(bvmgr.equal(ch1.formula,bvmgr.makeBitvector(16, (int) res)))
 		then:
 		!prover.isUnsat()
 		(ch1.concrete == res)
@@ -892,7 +892,7 @@ class IntValueTest extends Specification {
 
 		when:
 		def s1 = i1.I2S()
-		prover.addConstraint(imgr.equal(s1.formula,imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(s1.formula,bvmgr.makeBitvector(16, res)))
 		then:
 		!prover.isUnsat()
 		(s1.concrete == res)

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/LongValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/LongValueTest.groovy
@@ -8,10 +8,10 @@ import org.sosy_lab.common.ShutdownManager
 import org.sosy_lab.common.configuration.Configuration
 import org.sosy_lab.common.log.BasicLogManager
 import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager
 import org.sosy_lab.java_smt.api.BooleanFormulaManager
 import org.sosy_lab.java_smt.api.FloatingPointFormulaManager
 import org.sosy_lab.java_smt.api.FormulaManager
-import org.sosy_lab.java_smt.api.IntegerFormulaManager
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Shared
@@ -24,7 +24,7 @@ class LongValueTest extends Specification {
 	ProverEnvironment prover
 	FormulaManager fmgr
 	BooleanFormulaManager bmgr
-	IntegerFormulaManager imgr
+	BitvectorFormulaManager bvmgr
 	FloatingPointFormulaManager fpmgr
 
 	def setup() {
@@ -38,7 +38,7 @@ class LongValueTest extends Specification {
 				SolverContext.ProverOptions.GENERATE_MODELS)
 		fmgr = context.getFormulaManager()
 		bmgr = fmgr.getBooleanFormulaManager()
-		imgr = fmgr.getIntegerFormulaManager()
+		bvmgr = fmgr.getBitvectorFormulaManager()
 		fpmgr = fmgr.getFloatingPointFormulaManager()
 	}
 
@@ -103,7 +103,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LADD(l2)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -129,7 +129,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LAND(l2)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -157,8 +157,8 @@ class LongValueTest extends Specification {
 		Exception e = null
 		try {
 			l3 = l1.LDIV(l2)
-			prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
-			println fmgr.dumpFormula(imgr.equal(l3.formula, imgr.makeNumber(res)))
+			prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
+			println fmgr.dumpFormula(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		} catch (ArithmeticException a) {
 			e = a
 		}
@@ -189,7 +189,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LMUL(l2)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -214,7 +214,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l2 = l1.LNEG()
-		prover.addConstraint(imgr.equal(l2.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l2.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -236,7 +236,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LOR(l2)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -265,8 +265,8 @@ class LongValueTest extends Specification {
 		Exception e = null
 		try {
 			l3 = l1.LREM(l2)
-			prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
-			println fmgr.dumpFormula(imgr.equal(l3.formula, imgr.makeNumber(res)))
+			prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
+			println fmgr.dumpFormula(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		} catch (ArithmeticException a) {
 			e = a
 		}
@@ -297,7 +297,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LSHL(i1)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -323,7 +323,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LSHR(i1)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -349,7 +349,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LSUB(l2)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -375,7 +375,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LUSHR(i1)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -401,7 +401,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def l3 = l1.LXOR(l2)
-		prover.addConstraint(imgr.equal(l3.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(l3.formula, bvmgr.makeBitvector(64, res)))
 		then:
 		!prover.isUnsat()
 		noExceptionThrown()
@@ -427,7 +427,7 @@ class LongValueTest extends Specification {
 		when:
 
 		def i1 = l1.LCMP(l2)
-		prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 
 		then:
 		!prover.isUnsat()
@@ -493,7 +493,7 @@ class LongValueTest extends Specification {
 
 		when:
 		def i1 = l1.L2I()
-		prover.addConstraint(imgr.equal(i1.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(i1.formula, bvmgr.makeBitvector(32, res)))
 		then:
 		!prover.isUnsat()
 		(i1.concrete == res)
@@ -514,7 +514,7 @@ class LongValueTest extends Specification {
 
 		when:
 		def b1 = l1.asByteValue()
-		prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, res)))
 
 		then:
 		!prover.isUnsat()
@@ -539,10 +539,10 @@ class LongValueTest extends Specification {
 		when:
 		def b1 = l1.asByteValue()
 		// Constrain long: 10 <= l <= 20
-		prover.addConstraint(imgr.greaterOrEquals(l1.formula, imgr.makeNumber(10)))
-		prover.addConstraint(imgr.lessOrEquals(l1.formula, imgr.makeNumber(20)))
+		prover.addConstraint(bvmgr.greaterOrEquals(l1.formula, bvmgr.makeBitvector(64, 10), true))
+		prover.addConstraint(bvmgr.lessOrEquals(l1.formula, bvmgr.makeBitvector(64, 20), true))
 		// But require byte > 100 (impossible!)
-		prover.addConstraint(imgr.greaterThan(b1.formula, imgr.makeNumber(100)))
+		prover.addConstraint(bvmgr.greaterThan(b1.formula, bvmgr.makeBitvector(8, 100), true))
 
 		then:
 		prover.isUnsat()
@@ -556,11 +556,11 @@ class LongValueTest extends Specification {
 		when:
 		def b1 = l1.asByteValue()
 		// Constrain long: 10 <= l <= 100
-		prover.addConstraint(imgr.greaterOrEquals(l1.formula, imgr.makeNumber(10)))
-		prover.addConstraint(imgr.lessOrEquals(l1.formula, imgr.makeNumber(100)))
+		prover.addConstraint(bvmgr.greaterOrEquals(l1.formula, bvmgr.makeBitvector(64, 10), true))
+		prover.addConstraint(bvmgr.lessOrEquals(l1.formula, bvmgr.makeBitvector(64, 100), true))
 		// Require byte in valid range (10-100, all fit in byte)
-		prover.addConstraint(imgr.greaterOrEquals(b1.formula, imgr.makeNumber(10)))
-		prover.addConstraint(imgr.lessOrEquals(b1.formula, imgr.makeNumber(100)))
+		prover.addConstraint(bvmgr.greaterOrEquals(b1.formula, bvmgr.makeBitvector(8, 10), true))
+		prover.addConstraint(bvmgr.lessOrEquals(b1.formula, bvmgr.makeBitvector(8, 100), true))
 
 		then:
 		!prover.isUnsat()
@@ -572,7 +572,7 @@ class LongValueTest extends Specification {
 
 		when:
 		def s1 = l1.asShortValue()
-		prover.addConstraint(imgr.equal(s1.formula, imgr.makeNumber(res)))
+		prover.addConstraint(bvmgr.equal(s1.formula, bvmgr.makeBitvector(16, res)))
 
 		then:
 		!prover.isUnsat()
@@ -597,10 +597,10 @@ class LongValueTest extends Specification {
 		when:
 		def s1 = l1.asShortValue()
 		// Constrain long: 100 <= l <= 200
-		prover.addConstraint(imgr.greaterOrEquals(l1.formula, imgr.makeNumber(100)))
-		prover.addConstraint(imgr.lessOrEquals(l1.formula, imgr.makeNumber(200)))
+		prover.addConstraint(bvmgr.greaterOrEquals(l1.formula, bvmgr.makeBitvector(64, 100), true))
+		prover.addConstraint(bvmgr.lessOrEquals(l1.formula, bvmgr.makeBitvector(64, 200), true))
 		// But require short > 10000 (impossible!)
-		prover.addConstraint(imgr.greaterThan(s1.formula, imgr.makeNumber(10000)))
+		prover.addConstraint(bvmgr.greaterThan(s1.formula, bvmgr.makeBitvector(16, 10000), true))
 
 		then:
 		prover.isUnsat()
@@ -614,11 +614,11 @@ class LongValueTest extends Specification {
 		when:
 		def s1 = l1.asShortValue()
 		// Constrain long: 500 <= l <= 2000
-		prover.addConstraint(imgr.greaterOrEquals(l1.formula, imgr.makeNumber(500)))
-		prover.addConstraint(imgr.lessOrEquals(l1.formula, imgr.makeNumber(2000)))
+		prover.addConstraint(bvmgr.greaterOrEquals(l1.formula, bvmgr.makeBitvector(64, 500), true))
+		prover.addConstraint(bvmgr.lessOrEquals(l1.formula, bvmgr.makeBitvector(64, 2000), true))
 		// Require short in valid range (500-2000)
-		prover.addConstraint(imgr.greaterOrEquals(s1.formula, imgr.makeNumber(500)))
-		prover.addConstraint(imgr.lessOrEquals(s1.formula, imgr.makeNumber(2000)))
+		prover.addConstraint(bvmgr.greaterOrEquals(s1.formula, bvmgr.makeBitvector(16, 500), true))
+		prover.addConstraint(bvmgr.lessOrEquals(s1.formula, bvmgr.makeBitvector(16, 2000), true))
 
 		then:
 		!prover.isUnsat()
@@ -630,7 +630,7 @@ class LongValueTest extends Specification {
 
 		when:
 		def ch1 = l1.asCharValue()
-		prover.addConstraint(imgr.equal(ch1.formula, imgr.makeNumber((int)res)))
+		prover.addConstraint(bvmgr.equal(ch1.formula, bvmgr.makeBitvector(16, (int)res)))
 
 		then:
 		!prover.isUnsat()
@@ -656,11 +656,11 @@ class LongValueTest extends Specification {
 		when:
 		def ch1 = l1.asCharValue()
 		// Constrain long: 65 <= l <= 90 (ASCII 'A' to 'Z')
-		prover.addConstraint(imgr.greaterOrEquals(l1.formula, imgr.makeNumber(65)))
-		prover.addConstraint(imgr.lessOrEquals(l1.formula, imgr.makeNumber(90)))
+		prover.addConstraint(bvmgr.greaterOrEquals(l1.formula, bvmgr.makeBitvector(64, 65), true))
+		prover.addConstraint(bvmgr.lessOrEquals(l1.formula, bvmgr.makeBitvector(64, 90), true))
 		// Require char in valid range (65-90, 'A'-'Z')
-		prover.addConstraint(imgr.greaterOrEquals(ch1.formula, imgr.makeNumber(65)))
-		prover.addConstraint(imgr.lessOrEquals(ch1.formula, imgr.makeNumber(90)))
+		prover.addConstraint(bvmgr.greaterOrEquals(ch1.formula, bvmgr.makeBitvector(16, 65), false))
+		prover.addConstraint(bvmgr.lessOrEquals(ch1.formula, bvmgr.makeBitvector(16, 90), false))
 
 		then:
 		!prover.isUnsat()
@@ -674,10 +674,10 @@ class LongValueTest extends Specification {
 		when:
 		def ch1 = l1.asCharValue()
 		// Constrain long: 0 <= l <= 100
-		prover.addConstraint(imgr.greaterOrEquals(l1.formula, imgr.makeNumber(0)))
-		prover.addConstraint(imgr.lessOrEquals(l1.formula, imgr.makeNumber(100)))
+		prover.addConstraint(bvmgr.greaterOrEquals(l1.formula, bvmgr.makeBitvector(64, 0), true))
+		prover.addConstraint(bvmgr.lessOrEquals(l1.formula, bvmgr.makeBitvector(64, 100), true))
 		// But require char > 10000 (impossible!)
-		prover.addConstraint(imgr.greaterThan(ch1.formula, imgr.makeNumber(10000)))
+		prover.addConstraint(bvmgr.greaterThan(ch1.formula, bvmgr.makeBitvector(16, 10000), false))
 
 		then:
 		prover.isUnsat()

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/ShortValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/primitive/numeric/integral/ShortValueTest.groovy
@@ -7,9 +7,9 @@ import org.sosy_lab.common.ShutdownManager
 import org.sosy_lab.common.configuration.Configuration
 import org.sosy_lab.common.log.BasicLogManager
 import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.api.BitvectorFormulaManager
 import org.sosy_lab.java_smt.api.BooleanFormulaManager
 import org.sosy_lab.java_smt.api.FormulaManager
-import org.sosy_lab.java_smt.api.IntegerFormulaManager
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 import spock.lang.Specification
@@ -20,7 +20,7 @@ class ShortValueTest extends Specification {
     ProverEnvironment prover
     FormulaManager fmgr
     BooleanFormulaManager bmgr
-    IntegerFormulaManager imgr
+    BitvectorFormulaManager bvmgr
 
     def setup() {
         context = SolverContextFactory.createSolverContext(
@@ -32,7 +32,7 @@ class ShortValueTest extends Specification {
                 SolverContext.ProverOptions.GENERATE_MODELS)
         fmgr = context.getFormulaManager()
         bmgr = fmgr.getBooleanFormulaManager()
-        imgr = fmgr.getIntegerFormulaManager()
+        bvmgr = fmgr.getBitvectorFormulaManager()
     }
 
     def cleanup() {
@@ -76,10 +76,10 @@ class ShortValueTest extends Specification {
         when:
         def b1 = s1.asByteValue()
         // Constrain short: 10 <= s <= 50
-        prover.addConstraint(imgr.greaterOrEquals(s1.formula, imgr.makeNumber(10)))
-        prover.addConstraint(imgr.lessOrEquals(s1.formula, imgr.makeNumber(50)))
+        prover.addConstraint(bvmgr.greaterOrEquals(s1.formula, bvmgr.makeBitvector(16, 10), true))
+        prover.addConstraint(bvmgr.lessOrEquals(s1.formula, bvmgr.makeBitvector(16, 50), true))
         // Require byte == 42 (possible!)
-        prover.addConstraint(imgr.equal(b1.formula, imgr.makeNumber(42)))
+        prover.addConstraint(bvmgr.equal(b1.formula, bvmgr.makeBitvector(8, 42)))
 
         then:
         !prover.isUnsat()
@@ -94,10 +94,10 @@ class ShortValueTest extends Specification {
         when:
         def b1 = s1.asByteValue()
         // Constrain short: 10 <= s <= 20
-        prover.addConstraint(imgr.greaterOrEquals(s1.formula, imgr.makeNumber(10)))
-        prover.addConstraint(imgr.lessOrEquals(s1.formula, imgr.makeNumber(20)))
+        prover.addConstraint(bvmgr.greaterOrEquals(s1.formula, bvmgr.makeBitvector(16, 10), true))
+        prover.addConstraint(bvmgr.lessOrEquals(s1.formula, bvmgr.makeBitvector(16, 20), true))
         // But require byte > 100 (impossible!)
-        prover.addConstraint(imgr.greaterThan(b1.formula, imgr.makeNumber(100)))
+        prover.addConstraint(bvmgr.greaterThan(b1.formula, bvmgr.makeBitvector(8, 100), true))
 
         then:
         prover.isUnsat()
@@ -136,10 +136,10 @@ class ShortValueTest extends Specification {
         when:
         def c1 = s1.asCharValue()
         // Constrain short: 500 <= s <= 1500
-        prover.addConstraint(imgr.greaterOrEquals(s1.formula, imgr.makeNumber(500)))
-        prover.addConstraint(imgr.lessOrEquals(s1.formula, imgr.makeNumber(1500)))
+        prover.addConstraint(bvmgr.greaterOrEquals(s1.formula, bvmgr.makeBitvector(16, 500), true))
+        prover.addConstraint(bvmgr.lessOrEquals(s1.formula, bvmgr.makeBitvector(16, 1500), true))
         // Require char == 1000 (possible!)
-        prover.addConstraint(imgr.equal(c1.formula, imgr.makeNumber(1000)))
+        prover.addConstraint(bvmgr.equal(c1.formula, bvmgr.makeBitvector(16, 1000)))
 
         then:
         !prover.isUnsat()
@@ -154,10 +154,10 @@ class ShortValueTest extends Specification {
         when:
         def c1 = s1.asCharValue()
         // Constrain short to be negative: -200 <= s <= -50
-        prover.addConstraint(imgr.greaterOrEquals(s1.formula, imgr.makeNumber(-200)))
-        prover.addConstraint(imgr.lessOrEquals(s1.formula, imgr.makeNumber(-50)))
+        prover.addConstraint(bvmgr.greaterOrEquals(s1.formula, bvmgr.makeBitvector(16, -200), true))
+        prover.addConstraint(bvmgr.lessOrEquals(s1.formula, bvmgr.makeBitvector(16, -50), true))
         // But require char < 1000 (impossible - negative shorts map to high chars!)
-        prover.addConstraint(imgr.lessThan(c1.formula, imgr.makeNumber(1000)))
+        prover.addConstraint(bvmgr.lessThan(c1.formula, bvmgr.makeBitvector(16, 1000), false))
 
         then:
         prover.isUnsat()

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/reference/StringBuilderValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/reference/StringBuilderValueTest.groovy
@@ -28,7 +28,7 @@ class StringBuilderValueTest extends Specification {
     def prover = context.newProverEnvironment(
             SolverContext.ProverOptions.GENERATE_MODELS)
     def bmgr = context.getFormulaManager().getBooleanFormulaManager()
-    def imgr = context.getFormulaManager().getIntegerFormulaManager()
+    def bvmgr = context.getFormulaManager().getBitvectorFormulaManager()
     def smgr = context.getFormulaManager().getStringFormulaManager()
 
     def "substring(int start)" () {
@@ -215,8 +215,8 @@ class StringBuilderValueTest extends Specification {
 
         when:
         CharValue charValue = (CharValue) stringBuilderValue.invokeMethod("charAt", desc, args)
-        prover.addConstraint(imgr.equal(charValue.formula,
-                imgr.makeNumber(new StringBuilder(exampleString).charAt(index) as Integer)))
+        prover.addConstraint(bvmgr.equal(charValue.formula,
+                bvmgr.makeBitvector(16, new StringBuilder(exampleString).charAt(index) as Integer)))
 
         then:
         charValue.concrete == new StringBuilder(exampleString).charAt(index)
@@ -239,8 +239,8 @@ class StringBuilderValueTest extends Specification {
 
         when:
         IntValue index = (IntValue) stringBuilderValue.invokeMethod("indexOf", desc, args)
-        prover.addConstraint(imgr.equal(index.formula,
-                imgr.makeNumber(new StringBuilder(exampleString).indexOf(searchString))))
+        prover.addConstraint(bvmgr.equal(index.formula,
+                bvmgr.makeBitvector(32, new StringBuilder(exampleString).indexOf(searchString))))
 
         then:
         index.getConcrete() == new StringBuilder(exampleString).indexOf(searchString)

--- a/symbolic-executor/src/test/groovy/de/uzl/its/value/reference/lang/StringValueTest.groovy
+++ b/symbolic-executor/src/test/groovy/de/uzl/its/value/reference/lang/StringValueTest.groovy
@@ -9,7 +9,6 @@ import org.sosy_lab.java_smt.api.*
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import java.util.regex.Pattern
 
 import static java.lang.Thread.currentThread
 
@@ -26,13 +25,12 @@ class StringValueTest extends Specification {
     // keep descriptor identical to original to avoid surprises
     private static final Type[] STRING_DESC = [Type.getType("Ljava/lang/String")] as Type[]
 
-    // regexes reused across tests
-    private static final Pattern DEF_S1 = Pattern.compile("\\(define-fun\\s+s1\\s*\\(\\)\\s*String\\s*\"([^\"]*)\"", Pattern.DOTALL)
-    private static final Pattern DEF_S2 = Pattern.compile("\\(define-fun\\s+s2\\s*\\(\\)\\s*String\\s*\"([^\"]*)\"", Pattern.DOTALL)
-
     def setup() {
         ThreadHandler.init()
-        ThreadHandler.addThreadContext(currentThread().id)
+        if (ThreadHandler.hasThreadContext(currentThread().id)) {
+            ThreadHandler.removeThreadContext(currentThread().id)
+        }
+        ThreadHandler.addThreadContext(currentThread().id, "Test-Thread", -2)
         context = ThreadHandler.getSolverContext(currentThread().id)
         prover  = context.newProverEnvironment(SolverContext.ProverOptions.GENERATE_MODELS)
         fmgr    = context.formulaManager
@@ -51,7 +49,10 @@ class StringValueTest extends Specification {
     // ---- helpers ----
 
     private void addUFConstraintsFromTrace() {
-        ThreadHandler.getSymbolicTraceHandler(currentThread().id).getUFs().each { prover.addConstraint(it) }
+        // UF-defining constraints are recorded on the symbolic trace (see
+        // StringValue.invokeEqualsIgnoreCase); the trace is fresh per test
+        // because setup() recreates the thread context.
+        ThreadHandler.getSymbolicTraceHandler(currentThread().id).getConstraints().each { prover.addConstraint(it) }
     }
 
     /** Force the SMT result to disagree with the concrete Java result. */
@@ -63,14 +64,15 @@ class StringValueTest extends Specification {
         }
     }
 
-    private static String modelString(ProverEnvironment p) {
-        // Only convert to String right here, never let Groovy stringify the Model implicitly.
-        return p.getModel().toString()
-    }
-
-    private static String extractOrNull(Pattern pat, String text) {
-        def m = pat.matcher(text)
-        return m.find() ? m.group(1) : null
+    /**
+     * Evaluates both string formulas in the current model. Unlike scraping the
+     * model dump, Model.evaluate also assigns don't-care variables that the
+     * solver omits from its partial model.
+     */
+    private List<String> evaluateModel(def f1, def f2) {
+        prover.getModel().withCloseable { model ->
+            [model.evaluate(f1), model.evaluate(f2)]
+        }
     }
 
     // ---- tests ----
@@ -94,8 +96,7 @@ class StringValueTest extends Specification {
         noExceptionThrown()
 
         and:
-        def model = modelString(prover)
-        def s1Model = extractOrNull(DEF_S1, model)
+        def (s1Model, _) = evaluateModel(lhs.formula, rhs.formula)
         assert s1Model != null
         assert (s1Model.equalsIgnoreCase(s2)) != expected
 
@@ -136,8 +137,7 @@ class StringValueTest extends Specification {
         noExceptionThrown()
 
         and:
-        def model = modelString(prover)
-        def s1Model = extractOrNull(DEF_S1, model)
+        def (s1Model, _) = evaluateModel(lhs.formula, rhs.formula)
         assert s1Model != null
         assert s1Model.length() == s2.length()
         assert (s1Model.equalsIgnoreCase(s2)) != expected
@@ -176,9 +176,7 @@ class StringValueTest extends Specification {
         noExceptionThrown()
 
         and:
-        def model = modelString(prover)
-        def s1Model = extractOrNull(DEF_S1, model)
-        def s2Model = extractOrNull(DEF_S2, model) ?: s2
+        def (s1Model, s2Model) = evaluateModel(lhs.formula, rhs.formula)
         assert s1Model != null
         assert (s1Model.equalsIgnoreCase(s2Model)) != expected
 
@@ -186,16 +184,12 @@ class StringValueTest extends Specification {
         prover.pop()
 
         where:
+        // With both strings symbolic the concrete values do not constrain the
+        // solver, so every row is the same (expensive, minutes-long) query —
+        // one row per expected value is full coverage.
         s1       | s2       | expected
         "hello"  | "HELLO"  | true
-        "Hello"  | "hello"  | true
-        "test"   | "TEST"   | true
         "abc"    | "xyz"    | false
-        "short"  | "longer" | false
-        "same"   | "same"   | true
-        ""       | ""       | true
-        "a"      | ""       | false
-        "Case"   | "case"   | true
     }
 
     @Unroll
@@ -219,9 +213,7 @@ class StringValueTest extends Specification {
         noExceptionThrown()
 
         and:
-        def model = modelString(prover)
-        def s1Model = extractOrNull(DEF_S1, model)
-        def s2Model = extractOrNull(DEF_S2, model) ?: s2
+        def (s1Model, s2Model) = evaluateModel(lhs.formula, rhs.formula)
         assert s1Model != null
         assert s1Model.length() == 10
         assert (s1Model.equalsIgnoreCase(s2Model)) != expected

--- a/symbolic-executor/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/symbolic-executor/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,0 +1,1 @@
+de.uzl.its.swat.testsupport.EagerFailureRenderingExtension


### PR DESCRIPTION
## Summary

Stacked on #13. Makes `./gradlew test` fully green: **8709 tests, 0 failures** (BUILD SUCCESSFUL in ~8 min). Before this PR the suite could not even run to completion — a single `SWATAssert` failure halted the test JVM, and ~1700 value tests failed on a stale formula API.

### Production fixes (real bugs found by re-enabling the tests)

1. **`DoubleValue.DCMP` returned -1 for equal operands.** `concrete` is a boxed `Double`, so `concrete == f.concrete` compared references. DCMPG/DCMPL on equal doubles produced -1 instead of 0 in concrete execution. Fixed by explicit unboxing.

2. **float/double → byte/short/char narrowing was intractable for Z3.** The conversions lowered through integer theory (`fpToIntFormula` + integer `modulo` + sign-adjust ITE). Mixing FP, unbounded integers and `int2bv` made simple range queries unsolvable — one `asShortValue` UNSAT check ran 20+ minutes without terminating. The JVM spec defines these conversions as `d2i`/`f2i` followed by `i2b`/`i2s`/`i2c`, so they are now implemented exactly that way via the existing `D2I()`/`F2I()` (pure bitvector, saturation handled) and the `IntValue` bit-extract narrowings. The same queries now solve in milliseconds.

3. **`exitOnError` was a dead config key.** Set in every `.cfg` but read nowhere; `ErrorHandler.handleException` unconditionally called `Runtime.halt(-1)`. It is now wired into `Config` (default `true` — production behavior unchanged) and the handler rethrows instead of halting when disabled. The test task sets `exitOnError=false`, so assertion failures surface as ordinary test failures instead of killing the JVM and discarding all reports.

### Test-infrastructure fixes

4. **Duplicate instruction IDs across processor specs.** `GlobalStateForInstrumentation` resets its per-method counter on `setCid`/`setMid` but tracks seen IDs globally, so every spec re-instrumenting `TestClass.main` collided (17 of 18 `InternalInvocationSpec` tests failed). Each test now gets a unique method name (and sets the `mid` like production does).

5. **Value tests modernized to the bitvector API** (the bulk of the diff). All `IntegerFormulaManager` assertions converted to `BitvectorFormulaManager` with the correct width/signedness per type (int=32, long=64, short=16, byte=8, char=16 unsigned); `fpmgr` constraints unchanged. The Groovy-computed expected values were already correct — Java int arithmetic wraps exactly like 32-bit bitvectors, so these tests now genuinely verify overflow semantics, which the old integer-formula versions could not express.

6. **`StringValueTest` updated to current APIs** (`addThreadContext(long,String,int)`, trace `getConstraints()`), and model values are read via `Model.evaluate` instead of regex-scraping the model dump — Z3 omits don't-care variables from partial models, which made two cases compare against strings the solver never chose. The both-symbolic `equalsIgnoreCase` table is reduced to one row per expected value: with both strings symbolic, the row's concrete values don't constrain the solver, so 9 rows were 9 repetitions of the same minutes-long query (class runtime 36 min → ~7 min).

### Notes for reviewers

- Suite runtime is ~8 min, of which ~7 min is the two unconstrained both-symbolic `equalsIgnoreCase` queries — genuine Z3 string+UF solving. If that is too slow for CI, tagging them as slow tests and excluding them from the default task is a reasonable follow-up.
- ~~Known landmine~~ **Fixed in this PR** (`ab7ce66`, see EagerFailureRenderingExtension): previously: when a Spock condition fails, Gradle renders the failure message after `cleanup()` has closed the Z3 context; `NumericalValue.toString()` then calls `formula.toString()` on the closed context and Z3 aborts the JVM natively. While the suite is green this never triggers, but future failures in the value specs may crash the test JVM instead of reporting nicely. Worth a follow-up (e.g. cache the formula string lazily, or guard rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

