### PR TITLE
fix: repair javadoc generation for symbolic-executor

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4
     - name: Generate Javadoc
-      run: ./gradlew javadoc
+      run: ./gradlew :symbolic-executor:javadoc
     - name: Upload Javadoc
       uses: actions/upload-artifact@v4
       with:

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/instrument/Utils.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/instrument/Utils.java
@@ -95,6 +95,7 @@ public class Utils implements Opcodes {
      *     INVOKESTATIC Intrinsics.injectAssignment(<i>uid</i>, <i>value</i>)
      *     LDC <i>uid</i>
      *     INVOKESTATIC Intrinsics.liftValue(<i>uid</i>, <i>value</i>)
+     * </pre>
      *
      * @param type The type of the value to be lifted.
      * @return The sequence of instructions.

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/instrument/common/FieldInfo.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/instrument/common/FieldInfo.java
@@ -9,7 +9,6 @@ import org.objectweb.asm.Type;
  * @param declaringClass the class name in which the field is declared
  * @param name   the field name
  * @param desc   the field descriptor (type information)
- * @param type   the field type
  * @param access the field access flags
  */
 public record FieldInfo(String declaringClass, String name, String desc, int access) {

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/metadata/package-info.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/metadata/package-info.java
@@ -6,14 +6,15 @@
  *
  * <p>
  * The central component is {@link de.uzl.its.swat.metadata.ClassDepot}, which acts as a registry to track each class and
- * its fields. It uses two different template types:
+ * its fields. It exposes two interface views:
+ * </p>
  * <ul>
- *     <li>{@link de.uzl.its.swat.metadata.InstrumentationClassTemplate} - for assigning/creating field indices during
+ *     <li>{@link de.uzl.its.swat.metadata.ClassDepotInstrumentation} - for assigning/creating indices during
  *     the instrumentation process.</li>
- *     <li>{@link de.uzl.its.swat.metadata.RuntimeClassTemplate} - for looking up field indices at runtime.</li>
+ *     <li>{@link de.uzl.its.swat.metadata.ClassDepotRuntime} - for looking up indices at runtime.</li>
  * </ul>
- * <strong>{@link de.uzl.its.swat.metadata.ClassTemplate}</strong> is an abstract base for these template
- * implementations.
+ * <p>
+ * {@link de.uzl.its.swat.metadata.ClassTemplate} stores the per-class metadata backing both views.
  * </p>
  */
 package de.uzl.its.swat.metadata;

--- a/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/reference/lang/BoxedValue.java
+++ b/symbolic-executor/src/main/java/de/uzl/its/swat/symbolic/value/reference/lang/BoxedValue.java
@@ -32,7 +32,7 @@ public abstract class BoxedValue<V extends NumericalValue> extends ObjectValue<O
      *
      * Z3's str.from_int only works for non-negative integers (returns empty string for negative values).
      * This method handles the sign manually:
-     * - If value < 0: returns "-" + str.from_int(abs(value))
+     * - If {@code value < 0}: returns "-" + str.from_int(abs(value))
      * - Otherwise: returns str.from_int(value)
      *
      * @param formula The integer formula to convert to string


### PR DESCRIPTION
The `javadoc` job failed on its first-ever run on main (it only triggers on main pushes, and until #20 the workflow never got past tests). Two causes, both fixed:

1. **Job scope:** bare `./gradlew javadoc` built javadoc for every subproject, including demo target apps (`optaplanner-*`) with broken doc comments — but the job only uploads `symbolic-executor/build/docs/javadoc`. Now runs `:symbolic-executor:javadoc` only.
2. **Six real doclint errors in symbolic-executor:** stale `@param type` on the `FieldInfo` record, two dead `{@link}` references (`InstrumentationClassTemplate`/`RuntimeClassTemplate` don't exist — now point at `ClassDepotInstrumentation`/`ClassDepotRuntime`) plus an unbalanced `</p>` in the metadata `package-info`, an unescaped `<` in `BoxedValue`, and an unclosed `<pre>` in `Utils`.

`./gradlew :symbolic-executor:javadoc` builds clean locally (warnings remain, but only errors fail the task).

Note: this also unblocks the CI badge in #22 — the workflow badge stays red while any job fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)