### PR TITLE
SV-COMP: let SWAT use the full time budget (remove internal 180s / 60s cutoffs)

### DIFF
--- a/scripts/svcomp-package/run_swat.py
+++ b/scripts/svcomp-package/run_swat.py
@@ -53,8 +53,12 @@ def determine_result(output: List[str], property_file: str) -> Verdict:
 
 
 
-def run_command_with_timeout(cmd: list[str], timeout: int = 180) -> tuple[ExecutionStatus, list[str]]:
-    """Executes the given command and returns output from both STDOUT and STDERR."""
+def run_command_with_timeout(cmd: list[str], timeout: int | None = None) -> tuple[ExecutionStatus, list[str]]:
+    """Executes the given command and returns output from both STDOUT and STDERR.
+
+    timeout=None (the default) imposes no internal cutoff so SWAT can use the full
+    SV-COMP time budget; benchexec enforces the wall/CPU limit externally.
+    """
 
     logger.info(f'[TARGET EXECUTION]: Running command: {cmd}')
     output = []

--- a/symbolic-explorer/driver/SVCompDriver.py
+++ b/symbolic-explorer/driver/SVCompDriver.py
@@ -258,7 +258,7 @@ class SVCompDriver:
                 continue
             branch_found = True
             #logger.info(f'[SYMBOLIC EXPLORATION] Solving for branch {branch.id}')
-            sat, sol = StrategyService.solve_branch(branch)
+            sat, sol = StrategyService.solve_branch(branch, solver_timeout_ms=None)
              
             if sat == SATResult.SAT:
                 logger.info(f'[SYMBOLIC EXPLORATION] Found solution for branch {branch.id} {"skipped" if branch.skipped is None else "branched"}')

--- a/symbolic-explorer/solver/SolverHandler.py
+++ b/symbolic-explorer/solver/SolverHandler.py
@@ -358,7 +358,7 @@ class Z3Handler:
         return filepath
 
     @staticmethod
-    def solve(node: Any, path_constraints: list) -> Tuple[SATResult, Dict[str, Any]]:
+    def solve(node: Any, path_constraints: list, timeout_ms: int | None = 60 * 1000) -> Tuple[SATResult, Dict[str, Any]]:
         """
         Solve for the given node and path constraints using ConstraintCache (modern approach).
 
@@ -432,7 +432,8 @@ class Z3Handler:
             except Exception as e:
                 logger.warning(f"[SOLVER] Failed to save SMT formula: {e}")
 
-        solver.set("timeout", 60 * 1000)
+        if timeout_ms is not None:
+            solver.set("timeout", timeout_ms)
         t_start = time.time()
         res = solver.check()
         t_check = time.time() - t_start

--- a/symbolic-explorer/strategy/StrategyService.py
+++ b/symbolic-explorer/strategy/StrategyService.py
@@ -82,7 +82,7 @@ class StrategyService:
         return uf_definitions
 
     @staticmethod
-    def solve_branch(possible_branch: Node, endpoint_id=None):
+    def solve_branch(possible_branch: Node, endpoint_id=None, solver_timeout_ms: int | None = 60 * 1000):
         db = Database.instance()
 
         path_constraints = StrategyService.collect_path_constrains(possible_branch)
@@ -93,7 +93,7 @@ class StrategyService:
 
         inputs = possible_branch.inputs
 
-        sat, sol = Z3Handler.solve(possible_branch, path_constraints)
+        sat, sol = Z3Handler.solve(possible_branch, path_constraints, timeout_ms=solver_timeout_ms)
 
         if sat == SATResult.SAT:
             db.add_solution(branch_id=possible_branch.gid, sol=sol, inputs=inputs, endpoint_id=endpoint_id)

--- a/symbolic-explorer/svcomp/SVCompHandler.py
+++ b/symbolic-explorer/svcomp/SVCompHandler.py
@@ -192,7 +192,7 @@ class SVCompHandler:
             if not StrategyService.is_symbolic_branch(branch):
                 continue
             branch_found = True
-            sat, sol = StrategyService.solve_branch(branch)
+            sat, sol = StrategyService.solve_branch(branch, solver_timeout_ms=None)
              
             if sat == SATResult.SAT:
                 symbolic_vars = branch.inputs


### PR DESCRIPTION
## What
Removes SWAT's **internal** time cutoffs so the SV-COMP run uses the full competition time budget (benchexec's 15 min) instead of giving up far earlier.

### Changes
1. **`scripts/svcomp-package/run_swat.py`** — the symbolic-execution run was hard-killed at **180 s** (`run_command_with_timeout` default). Default is now `None` (no internal cutoff); benchexec enforces the wall/CPU limit externally.
2. **Z3 solver 60 s timeout — removed for the sv-comp path only.** `Z3Handler.solve` and `StrategyService.solve_branch` gain a `timeout_ms` parameter (default **60 s**, so `passive`/`http`/`target`/`simple` modes are unchanged); `SVCompDriver` and `SVCompHandler` pass `None`. `solve_with_optimization` is left untouched (it is not on the sv-comp `solve_branch` path).

### Why
Both cutoffs pre-empted SWAT well before the competition's 15 min limit, turning solvable tasks into `unknown`. Z3 already returns `UNKNOWN` on hard constraints and the explorer handles that (`SATResult.UNKNOWN → REPORTVERDICT`), so benchexec's limit is the right — and now only — backstop.

### Tradeoff
Hard tasks may now run up to the full 15 min instead of ~3 min, so full-suite wall-clock grows. Intended (more coverage); managed on the benchmarking side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)